### PR TITLE
Add doctrine:queue:work command for safely handling queued jobs with Doctrine (DEV-2364)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+# Description of Changes
+<!-- Provide a general summary of the changes. -->
+
+## Paired With
+<!-- Tag developers that were involved in the development of this pull request. -->
+
+## Resolves
+<!-- Jira ticket numbers. Separate each with a new line. e.g. DEV-1234 -->
+
+## Blocked By
+<!-- Github Pull Request numbers. Separate each with a new line. e.g. #1234 -->
+
+## Testing
+<!-- Steps on how to test these changes. -->
+
+Steps:
+1.
+2.
+3.
+4.
+
+## Checklist
+<!--
+    Please verify the following.
+    If any boxes are unchecked, please provide a reason in the additional information section.
+-->
+<!-- A filled checkbox should look like this: [x] -->
+
+- [ ] I have labeled this PR appropriately. 
+- [ ] My code follows the formatting guidelines of this project.
+- [ ] I have added types on all class properties and function definitions (both parameters and return types).
+- [ ] I have updated all JSDoc and PHPDoc comments.
+- [ ] I have commented my code in hard-to-understand areas.
+- [ ] I have created tests to show the ticket has been resolved.
+- [ ] I have self-reviewed my completed code.
+- [ ] I have tested my changes as well as any areas that may be affected by the change.
+
+## Additional Information
+<!-- Please provide any additional information regarding your changes. -->

--- a/.github/workflows/basic-continuous-integration.yml
+++ b/.github/workflows/basic-continuous-integration.yml
@@ -28,3 +28,4 @@ jobs:
           configuration: phpunit.xml
           version: 9
           php_version: 7.4
+          args: test

--- a/.github/workflows/basic-continuous-integration.yml
+++ b/.github/workflows/basic-continuous-integration.yml
@@ -18,9 +18,6 @@ jobs:
           extensions: intl
           tools: composer:v1
 
-      - name: Copy .env
-        run: cp .env.testing .env
-
       - name: Cache Composer packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/basic-continuous-integration.yml
+++ b/.github/workflows/basic-continuous-integration.yml
@@ -11,13 +11,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          extensions: intl
-          tools: composer:v1
-
       - name: Cache Composer packages
         uses: actions/cache@v2
         with:
@@ -28,5 +21,10 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --dev --no-interaction --no-progress
 
-      - name: Execute Unit tests
-        run: vendor/bin/phpunit test
+      - name: PHPUnit Tests
+        uses: php-actions/phpunit@v2
+        with:
+          bootstrap: vendor/autoload.php
+          configuration: phpunit.xml
+          version: 9
+          php_version: 7.4

--- a/.github/workflows/basic-continuous-integration.yml
+++ b/.github/workflows/basic-continuous-integration.yml
@@ -29,4 +29,4 @@ jobs:
         run: composer install --dev --no-interaction --no-progress
 
       - name: Execute Unit tests
-        run: vendor/bin/phpunit --testsuite=Unit
+        run: vendor/bin/phpunit test

--- a/.github/workflows/basic-continuous-integration.yml
+++ b/.github/workflows/basic-continuous-integration.yml
@@ -1,0 +1,35 @@
+name: Basic Continuous Integration
+
+on: [push]
+
+jobs:
+  phpunit-unit:
+    name: PHPUnit Unit Tests
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: intl
+          tools: composer:v1
+
+      - name: Copy .env
+        run: cp .env.testing .env
+
+      - name: Cache Composer packages
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.composer/cache/files
+          key: composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install Composer dependencies
+        run: composer install --dev --no-interaction --no-progress
+
+      - name: Execute Unit tests
+        run: vendor/bin/phpunit --testsuite=Unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 .idea
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor
-vendor/phpdocumentor/type-resolver/composer.lock
+composer.lock
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 vendor/phpdocumentor/type-resolver/composer.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+vendor/phpdocumentor/type-resolver/composer.lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# doctrine-queue-worker
+**doctrine-queue-worker** is a package intended address some issues with running Laravel 8.x queue worker processes with an application that interacts with the Doctrine ORM.
+### Features
+
+- Re-queues jobs and kills the worker process when the Doctrine EntityManager closes due to an exception.
+- Re-queues jobs and kills the worker process when the connection to the database dies.
+
+### Usage
+
+- Setup worker processes to invoke the `doctine:queue:work` artisan command. Options for the command are the same as the built-in Laravel `queue:work` command.
+- Use a process manager like supervisor to ensure your queue workers will be restarted after they die.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # doctrine-queue-worker
-**doctrine-queue-worker** is a package intended address some issues with running Laravel 8.x queue worker processes with an application that interacts with the Doctrine ORM.
+**doctrine-queue-worker** is a package intended to address common issues with running Laravel 8.x queue worker processes with an application that interacts with the Doctrine ORM.
+
 ### Features
 
-- Re-queues jobs and kills the worker process when the Doctrine EntityManager closes due to an exception.
-- Re-queues jobs and kills the worker process when the connection to the database dies.
+- Re-queues jobs and kills the worker process when the `EntityManager` closes due to an exception.
+- Ensures the `EntityManager`'s database connection remains open between jobs.
+- Clears the `EntityManager` between job executions.
+
+### Installation
+
+- Require the library via Composer: `composer install pinnacle/doctrine-queue-worker`
+- Add the `DoctrineQueueWorkerServiceProvider` class to your `app.php` file.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 
 ### Installation
 
-- Require the library via Composer: `composer install pinnacle/doctrine-queue-worker`
-- Add the `DoctrineQueueWorkerServiceProvider` class to your `app.php` file.
+- Require the library via Composer: `composer require pinnacle/doctrine-queue-worker`
 
 ### Usage
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+  "name": "pinnacle/doctrine-queue-worker",
+  "description": "A worker for Laravel applications that interact with Doctrine",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Cody Woolsey",
+      "email": "cody.woolsey@pinnacleqi.com"
+    },
+    {
+      "name": "Chris Schwerdt",
+      "email": "chris.schwerdt@pinnacleqi.com"
+    }
+  ],
+  "require": {
+    "php": ">=7.4",
+    "illuminate/queue": "^8.0",
+    "laravel-doctrine/orm": "^1.5"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.3",
+    "mockery/mockery": "^1.3.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Pinnacle\\Queue\\": "src/Pinnacle/Queue"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "test\\Pinnacle\\Queue\\": "tests/"
+    }
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,14 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "test\\Pinnacle\\Queue\\": "tests/"
+      "test\\Pinnacle\\Queue\\": "test"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Pinnacle\\Queue\\DoctrineQueueWorkerServiceProvider"
+      ]
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false"
+         stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,12 +5,12 @@
          stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <coverage processUncoveredFiles="true">
         <include>
-            <directory suffix=".php">./src</directory>
+            <directory suffix=".php">src</directory>
         </include>
     </coverage>
     <testsuites>
         <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,12 +5,12 @@
          stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <coverage processUncoveredFiles="true">
         <include>
-            <directory suffix=".php">src</directory>
+            <directory suffix=".php">./src</directory>
         </include>
     </coverage>
     <testsuites>
         <testsuite name="Unit">
-            <directory suffix="Test.php">tests</directory>
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
     </coverage>
     <testsuites>
         <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
+            <directory suffix="Test.php">./test</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Pinnacle/Queue/Console/DoctrineQueueWorkerCommand.php
+++ b/src/Pinnacle/Queue/Console/DoctrineQueueWorkerCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinnacle\Queue\Console;
+
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Queue\Console\WorkCommand;
+use Illuminate\Queue\Worker;
+
+class DoctrineQueueWorkerCommand extends WorkCommand
+{
+    protected $signature   = 'doctrine:queue:work';
+
+    protected $description = 'Works jobs from the queue in a way that\'s compatible with Doctrine.';
+
+    public function __construct(Worker $worker, Cache $cache)
+    {
+        parent::__construct($worker, $cache);
+    }
+}

--- a/src/Pinnacle/Queue/DoctrineQueueWorker.php
+++ b/src/Pinnacle/Queue/DoctrineQueueWorker.php
@@ -43,7 +43,7 @@ class DoctrineQueueWorker extends Worker
             // since the parent runJob method catches all exceptions that occur during job execution.
             $this->exceptions->report($exception);
             $this->requeueJob($job);
-            $this->killWorkerProcess();
+            $this->signalWorkerProcessShouldStop();
         }
     }
 
@@ -97,7 +97,7 @@ class DoctrineQueueWorker extends Worker
     /**
      * Kills the worker process so it can be restarted by a process supervisor.
      */
-    private function killWorkerProcess(): void
+    private function signalWorkerProcessShouldStop(): void
     {
         $this->shouldQuit = true;
     }

--- a/src/Pinnacle/Queue/DoctrineQueueWorker.php
+++ b/src/Pinnacle/Queue/DoctrineQueueWorker.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinnacle\Queue;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMException;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\Factory as QueueManager;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Worker;
+use Illuminate\Queue\WorkerOptions;
+use Throwable;
+
+class DoctrineQueueWorker extends Worker
+{
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(
+        QueueManager $manager,
+        Dispatcher $events,
+        EntityManagerInterface $entityManager,
+        ExceptionHandler $exceptions,
+        callable $isDownForMaintenance
+    ) {
+        $this->entityManager = $entityManager;
+
+        parent::__construct($manager, $events, $exceptions, $isDownForMaintenance);
+    }
+
+    protected function runJob($job, $connectionName, WorkerOptions $options): void
+    {
+        try {
+            $this->assertEntityManagerIsOpen();
+            $this->ensureDatabaseConnectionIsOpen();
+            $this->clearEntityManager();
+
+            parent::runJob($job, $connectionName, $options);
+        } catch (Throwable $exception) {
+            // It's safe to assume that any exceptions caught by this block are a result of our assertions or setup,
+            // since the parent runJob method catches all exceptions that occur during job execution.
+            $this->exceptions->report($exception);
+            $this->requeueJob($job);
+            $this->killWorkerProcess();
+        }
+    }
+
+    /**
+     * Asserts that the EntityManager is not closed.
+     *
+     * @throws ORMException If the EntityManager is closed.
+     */
+    private function assertEntityManagerIsOpen(): void
+    {
+        if ($this->entityManager->isOpen()) {
+            return;
+        }
+
+        throw new ORMException('The entity manager is closed.');
+    }
+
+    /**
+     * Pings the EntityManager's database connection to ensure that it is still open. If the connection is not open,
+     * this method will attempt to re-open the connection.
+     */
+    private function ensureDatabaseConnectionIsOpen(): void
+    {
+        $connection = $this->entityManager->getConnection();
+        if (!$connection->ping()) {
+            $connection->close();
+            $connection->connect();
+        }
+    }
+
+    /**
+     * Clears the EntityManager to ensure that nothing persists between job runs.
+     */
+    private function clearEntityManager(): void
+    {
+        $this->entityManager->clear();
+    }
+
+    /**
+     * Immediately places the job back on the queue so it can be handled by a different worker process (or the same
+     * worker process if it restarts before the job is processed). We don't respect the configured "backoff" option
+     * for the job here, since if we reach this point it means the job was never actually processed.
+     */
+    private function requeueJob(Job $job): void
+    {
+        if (!$job->isDeleted() && !$job->isReleased() && !$job->hasFailed()) {
+            $job->release();
+        }
+    }
+
+    /**
+     * Kills the worker process so it can be restarted by a process supervisor.
+     */
+    private function killWorkerProcess(): void
+    {
+        $this->shouldQuit = true;
+    }
+}

--- a/src/Pinnacle/Queue/DoctrineQueueWorker.php
+++ b/src/Pinnacle/Queue/DoctrineQueueWorker.php
@@ -35,7 +35,7 @@ class DoctrineQueueWorker extends Worker
         try {
             $this->assertEntityManagerIsOpen();
             $this->ensureDatabaseConnectionIsOpen();
-            $this->clearEntityManager();
+            $this->ensureEntityManagerIsClear();
 
             parent::runJob($job, $connectionName, $options);
         } catch (Throwable $exception) {
@@ -77,7 +77,7 @@ class DoctrineQueueWorker extends Worker
     /**
      * Clears the EntityManager to ensure that nothing persists between job runs.
      */
-    private function clearEntityManager(): void
+    private function ensureEntityManagerIsClear(): void
     {
         $this->entityManager->clear();
     }

--- a/src/Pinnacle/Queue/DoctrineQueueWorkerServiceProvider.php
+++ b/src/Pinnacle/Queue/DoctrineQueueWorkerServiceProvider.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Pinnacle\Queue;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Pinnacle\Queue\Console\DoctrineQueueWorkerCommand;
 
-class DoctrineQueueWorkerServiceProvider extends ServiceProvider
+class DoctrineQueueWorkerServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    protected $defer = true;
-
     public function register(): void
     {
         $this->registerWorker();

--- a/src/Pinnacle/Queue/DoctrineQueueWorkerServiceProvider.php
+++ b/src/Pinnacle/Queue/DoctrineQueueWorkerServiceProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinnacle\Queue;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\ServiceProvider;
+use Pinnacle\Queue\Console\DoctrineQueueWorkerCommand;
+
+class DoctrineQueueWorkerServiceProvider extends ServiceProvider
+{
+    protected $defer = true;
+
+    public function register(): void
+    {
+        $this->registerWorker();
+        $this->registerWorkCommand();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function provides(): array
+    {
+        return [
+            DoctrineQueueWorkerCommand::class,
+            DoctrineQueueWorker::class
+        ];
+    }
+
+    private function registerWorker(): void
+    {
+        $this->app->singleton(
+            DoctrineQueueWorker::class,
+            function ($app): DoctrineQueueWorker {
+                $isDownForMaintenance = function () {
+                    return $this->app->isDownForMaintenance();
+                };
+
+                return new DoctrineQueueWorker(
+                    $app['queue'],
+                    $app['events'],
+                    $app['em'],
+                    $app[ExceptionHandler::class],
+                    $isDownForMaintenance
+                );
+            }
+        );
+    }
+
+    private function registerWorkCommand(): void
+    {
+        $this->app->singleton(
+            DoctrineQueueWorkerCommand::class,
+            fn ($app) => new DoctrineQueueWorkerCommand($app[DoctrineQueueWorker::class], $app['cache'])
+        );
+    }
+}

--- a/src/Pinnacle/Queue/DoctrineQueueWorkerServiceProvider.php
+++ b/src/Pinnacle/Queue/DoctrineQueueWorkerServiceProvider.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Pinnacle\Queue;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Pinnacle\Queue\Console\DoctrineQueueWorkerCommand;
@@ -32,15 +34,15 @@ class DoctrineQueueWorkerServiceProvider extends ServiceProvider implements Defe
     {
         $this->app->singleton(
             DoctrineQueueWorker::class,
-            function ($app): DoctrineQueueWorker {
-                $isDownForMaintenance = function () {
+            function (Application $app): DoctrineQueueWorker {
+                $isDownForMaintenance = function (): bool {
                     return $this->app->isDownForMaintenance();
                 };
 
                 return new DoctrineQueueWorker(
                     $app['queue'],
                     $app['events'],
-                    $app['em'],
+                    $app[EntityManagerInterface::class],
                     $app[ExceptionHandler::class],
                     $isDownForMaintenance
                 );

--- a/test/Pinnacle/Queue/DoctrineQueueWorkerTest.php
+++ b/test/Pinnacle/Queue/DoctrineQueueWorkerTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinnacle\Queue;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Queue\WorkerOptions;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class DoctrineQueueWorkerTest extends TestCase
+{
+    /**
+     * @var MockInterface|QueueManager
+     */
+    private MockInterface $queueManager;
+
+    /**
+     * @var MockInterface|Queue
+     */
+    private MockInterface $queue;
+
+    /**
+     * @var MockInterface|Dispatcher
+     */
+    private MockInterface $dispatcher;
+
+    /**
+     * @var MockInterface|EntityManagerInterface
+     */
+    private MockInterface $entityManager;
+
+    /**
+     * @var MockInterface|Connection
+     */
+    private MockInterface $connection;
+
+    /**
+     * @var MockInterface|Repository
+     */
+    private MockInterface $cache;
+
+    /**
+     * @var MockInterface|ExceptionHandler
+     */
+    private MockInterface $exceptions;
+    /**
+     * @var DoctrineQueueWorker
+     */
+    private DoctrineQueueWorker $worker;
+    /**
+     * @var WorkerOptions
+     */
+    private WorkerOptions $workerOptions;
+
+    protected function setUp(): void
+    {
+        $this->queueManager   = Mockery::mock(QueueManager::class);
+        $this->queue          = Mockery::mock(Queue::class);
+        $this->dispatcher     = Mockery::mock(Dispatcher::class);
+        $this->entityManager  = Mockery::mock(EntityManagerInterface::class);
+        $this->connection     = Mockery::mock(Connection::class);
+        $this->cache          = Mockery::mock(Repository::class);
+        $this->exceptions     = Mockery::mock(ExceptionHandler::class);
+        $isDownForMaintenance = fn () => false;
+
+        $this->worker = new DoctrineQueueWorker(
+            $this->queueManager,
+            $this->dispatcher,
+            $this->entityManager,
+            $this->exceptions,
+            $isDownForMaintenance
+        );
+        $this->workerOptions = new WorkerOptions(
+            'default',
+            0,
+            128,
+            60,
+            1,
+            3
+        );
+
+        $this->exceptions->shouldIgnoreMissing();
+        $this->entityManager->shouldReceive('getConnection')->andReturn($this->connection);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    /**
+     * @test
+     */
+    public function runNextJob_EntityManagerIsClosed_JobRequeuedAndWorkerSetToExit(): void
+    {
+        // Assemble
+        $this->entityManager->shouldReceive('isOpen')->andReturn(false);
+        $this->entityManager->shouldNotReceive('clear');
+
+        $job = Mockery::mock(Job::class);
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('release')->once();
+
+        $this->prepareQueue($job);
+
+        // Act
+        $this->worker->runNextJob('connection', 'default', $this->workerOptions);
+
+        // Assert
+        $this->assertTrue($this->worker->shouldQuit);
+    }
+
+    /**
+     * @test
+     */
+    public function runNextJob_EntityManagerClosedAndJobFailed_JobNotRequeuedAndWorkerSetToExit(): void
+    {
+        // Assemble
+        $this->entityManager->shouldReceive('isOpen')->andReturn(false);
+        $this->entityManager->shouldNotReceive('clear');
+
+        $job = Mockery::mock(Job::class);
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('hasFailed')->andReturn(true);
+        $job->shouldNotReceive('release');
+
+        $this->prepareQueue($job);
+
+        // Act
+        $this->worker->runNextJob('connection', 'default', $this->workerOptions);
+
+        // Assert
+        $this->assertTrue($this->worker->shouldQuit);
+    }
+
+    /**
+     * @test
+     */
+    public function runNextJob_DatabaseConnectionClosed_ShouldReOpenConnection(): void
+    {
+        // Assemble
+        $this->entityManager->shouldReceive('isOpen')->andReturn(true);
+        $this->entityManager->shouldReceive('clear');
+
+        $this->connection->shouldReceive('ping')->andReturn(false);
+        $this->connection->shouldReceive('close');
+        $this->connection->shouldReceive('connect');
+
+        $job = Mockery::mock(Job::class);
+        $job->shouldIgnoreMissing();
+
+        $this->prepareQueue($job);
+
+        // Act
+        $this->worker->runNextJob('connection', 'default', $this->workerOptions);
+
+        // Assert
+        $this->assertFalse($this->worker->shouldQuit);
+    }
+
+    /**
+     * @test
+     */
+    public function runNextJob_EntityManagerAndConnectionOpen_ShouldClearEntityManager(): void
+    {
+        // Assemble
+        $this->entityManager->shouldReceive('isOpen')->andReturn(true);
+        $this->entityManager->shouldReceive('clear');
+
+        $this->connection->shouldReceive('ping')->andReturn(true);
+        $this->connection->shouldNotReceive('close');
+        $this->connection->shouldNotReceive('connect');
+
+        $job = Mockery::mock(Job::class);
+        $job->shouldIgnoreMissing();
+
+        $this->prepareQueue($job);
+
+        // Act
+        $this->worker->runNextJob('connection', 'default', $this->workerOptions);
+
+        // Assert
+        $this->assertFalse($this->worker->shouldQuit);
+    }
+
+    /**
+     * @test
+     */
+    public function runNextJob_JobThrowsException_ShouldRequeueJobAndNotKillWorkerProcess(): void
+    {
+        // Assemble
+        $this->entityManager->shouldReceive('isOpen')->andReturn(true);
+        $this->entityManager->shouldReceive('clear');
+
+        $this->connection->shouldReceive('ping')->andReturn(true);
+        $this->connection->shouldNotReceive('close');
+        $this->connection->shouldNotReceive('connect');
+
+        $job = Mockery::mock(Job::class);
+        $job->shouldReceive('handle')->andThrow(new Exception('test'));
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('release')->once();
+        $job->shouldIgnoreMissing();
+
+        $this->prepareQueue($job);
+
+        // Act
+        $this->worker->runNextJob('connection', 'default', $this->workerOptions);
+
+        // Assert
+        $this->assertFalse($this->worker->shouldQuit);
+    }
+
+    /**
+     * @param MockInterface|Job $job
+     */
+    private function prepareQueue(MockInterface $job): void
+    {
+        $this->queueManager->shouldReceive('isDownForMaintenance')->andReturn(false);
+        $this->queueManager->shouldReceive('connection')->andReturn($this->queue);
+        $this->queueManager->shouldReceive('getName')->andReturn('default');
+
+        $this->queue->shouldReceive('pop')->andReturn(...[$job]);
+    }
+}

--- a/test/Pinnacle/Queue/DoctrineQueueWorkerTest.php
+++ b/test/Pinnacle/Queue/DoctrineQueueWorkerTest.php
@@ -63,42 +63,6 @@ class DoctrineQueueWorkerTest extends TestCase
      */
     private WorkerOptions $workerOptions;
 
-    protected function setUp(): void
-    {
-        $this->queueManager   = Mockery::mock(QueueManager::class);
-        $this->queue          = Mockery::mock(Queue::class);
-        $this->dispatcher     = Mockery::mock(Dispatcher::class);
-        $this->entityManager  = Mockery::mock(EntityManagerInterface::class);
-        $this->connection     = Mockery::mock(Connection::class);
-        $this->cache          = Mockery::mock(Repository::class);
-        $this->exceptions     = Mockery::mock(ExceptionHandler::class);
-        $isDownForMaintenance = fn () => false;
-
-        $this->worker = new DoctrineQueueWorker(
-            $this->queueManager,
-            $this->dispatcher,
-            $this->entityManager,
-            $this->exceptions,
-            $isDownForMaintenance
-        );
-        $this->workerOptions = new WorkerOptions(
-            'default',
-            0,
-            128,
-            60,
-            1,
-            3
-        );
-
-        $this->exceptions->shouldIgnoreMissing();
-        $this->entityManager->shouldReceive('getConnection')->andReturn($this->connection);
-    }
-
-    protected function tearDown(): void
-    {
-        Mockery::close();
-    }
-
     /**
      * @test
      */
@@ -225,6 +189,42 @@ class DoctrineQueueWorkerTest extends TestCase
 
         // Assert
         $this->assertFalse($this->worker->shouldQuit);
+    }
+
+    protected function setUp(): void
+    {
+        $this->queueManager   = Mockery::mock(QueueManager::class);
+        $this->queue          = Mockery::mock(Queue::class);
+        $this->dispatcher     = Mockery::mock(Dispatcher::class);
+        $this->entityManager  = Mockery::mock(EntityManagerInterface::class);
+        $this->connection     = Mockery::mock(Connection::class);
+        $this->cache          = Mockery::mock(Repository::class);
+        $this->exceptions     = Mockery::mock(ExceptionHandler::class);
+        $isDownForMaintenance = fn () => false;
+
+        $this->worker = new DoctrineQueueWorker(
+            $this->queueManager,
+            $this->dispatcher,
+            $this->entityManager,
+            $this->exceptions,
+            $isDownForMaintenance
+        );
+        $this->workerOptions = new WorkerOptions(
+            'default',
+            0,
+            128,
+            60,
+            1,
+            3
+        );
+
+        $this->exceptions->shouldIgnoreMissing();
+        $this->entityManager->shouldReceive('getConnection')->andReturn($this->connection);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
     }
 
     /**

--- a/test/Pinnacle/Queue/DoctrineQueueWorkerTest.php
+++ b/test/Pinnacle/Queue/DoctrineQueueWorkerTest.php
@@ -54,10 +54,12 @@ class DoctrineQueueWorkerTest extends TestCase
      * @var MockInterface|ExceptionHandler
      */
     private MockInterface $exceptions;
+
     /**
      * @var DoctrineQueueWorker
      */
     private DoctrineQueueWorker $worker;
+
     /**
      * @var WorkerOptions
      */

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,2 +1,0 @@
-/vendor
-composer.lock

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock


### PR DESCRIPTION
# Description of Changes
<!-- Provide a general summary of the changes. -->

- Adds a new `doctrine:queue:work` artisan command for safely handling jobs that interact with the Doctrine ORM.
- Provides a wrapper around the queue worker's `runJob` method to ensure the database connection is open, clear the `EntityManager`, and kill the worker process if the `EntityManager` is closed.

## Resolves
<!-- Jira ticket numbers. Separate each with a new line. e.g. DEV-1234 -->

DEV-2364

## Testing
<!-- Steps on how to test these changes. -->

It's going to be easiest to perform functional testing after pulling this library into RETAIN. For now, executing the unit tests should be adequate for testing.

## Checklist
<!--
    Please verify the following.
    If any boxes are unchecked, please provide a reason in the additional information section.
-->
<!-- A filled checkbox should look like this: [x] -->

- [x] I have labeled this PR appropriately. 
- [x] My code follows the formatting guidelines of this project.
- [x] I have added types on all class properties and function definitions (both parameters and return types).
- [x] I have updated all JSDoc and PHPDoc comments.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have created tests to show the ticket has been resolved.
- [x] I have self-reviewed my completed code.
- [ ] I have tested my changes as well as any areas that may be affected by the change.