### PR TITLE
Update Illuminate and Laravel Doctrine dependencies 

### DIFF
--- a/.github/workflows/basic-continuous-integration.yml
+++ b/.github/workflows/basic-continuous-integration.yml
@@ -21,15 +21,7 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --dev --no-interaction --no-progress
 
-      - name: PHPUnit Tests (PHP 7.4)
-        uses: php-actions/phpunit@v2
-        with:
-          bootstrap: vendor/autoload.php
-          configuration: phpunit.xml
-          version: 9
-          php_version: 7.4
-
-      - name: PHPUnit Tests (PHP 8.0)
+      - name: PHPUnit Tests
         uses: php-actions/phpunit@v2
         with:
           bootstrap: vendor/autoload.php

--- a/.github/workflows/basic-continuous-integration.yml
+++ b/.github/workflows/basic-continuous-integration.yml
@@ -27,4 +27,4 @@ jobs:
           bootstrap: vendor/autoload.php
           configuration: phpunit.xml
           version: 9
-          php_version: 7.4
+          php_version: 8.0

--- a/.github/workflows/basic-continuous-integration.yml
+++ b/.github/workflows/basic-continuous-integration.yml
@@ -21,10 +21,19 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --dev --no-interaction --no-progress
 
-      - name: PHPUnit Tests
+      - name: PHPUnit Tests (PHP 7.4)
+        uses: php-actions/phpunit@v2
+        with:
+          bootstrap: vendor/autoload.php
+          configuration: phpunit.xml
+          version: 9
+          php_version: 7.4
+
+      - name: PHPUnit Tests (PHP 8.0)
         uses: php-actions/phpunit@v2
         with:
           bootstrap: vendor/autoload.php
           configuration: phpunit.xml
           version: 9
           php_version: 8.0
+

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0.2",
         "doctrine/orm": "^2.6",
         "illuminate/contracts": "^9.0",
         "illuminate/queue": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     "require": {
         "php": ">=7.4",
         "doctrine/orm": "^2.6",
-        "illuminate/contracts": "^8.0",
-        "illuminate/queue": "^8.0",
-        "illuminate/support": "^8.0",
-        "laravel-doctrine/orm": "^1.5"
+        "illuminate/contracts": "^9.0",
+        "illuminate/queue": "^9.0",
+        "illuminate/support": "^9.0",
+        "laravel-doctrine/orm": "^1.8"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         }
     ],
     "require": {
-        "php": ">=8.0.2",
+        "php": "^7.4|^8.0",
         "doctrine/orm": "^2.6",
-        "illuminate/contracts": "^9.0",
-        "illuminate/queue": "^9.0",
-        "illuminate/support": "^9.0",
-        "laravel-doctrine/orm": "^1.8"
+        "illuminate/contracts": "^8.0|^9.0",
+        "illuminate/queue": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0",
+        "laravel-doctrine/orm": "^1.5"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",


### PR DESCRIPTION
### Description

This PR updates the following dependencies.

```
"illuminate/contracts": "^9.0",
"illuminate/queue": "^9.0",
"illuminate/support": "^9.0",
"laravel-doctrine/orm": "^1.8"
```


### Testing
Install dependencies and check that the tests pass.